### PR TITLE
Escape exclamation mark in yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous integration
 
 on:
-  push:
+  pull_request:
     branches-ignore:
       - release
 
@@ -48,7 +48,7 @@ jobs:
         with:
           command: build
       - name: Check that we didn't introduce native ssl
-        run: ! ldd ../target/debug/svanill-vault-cli | grep -q libssl
+        run: '! ldd ../target/debug/svanill-vault-cli | grep -q libssl'
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
A value starting with exclamation mark (!) has a special meaning in YAML, so the following line present in one action file broke the CI and we have to escape it

```
run: ! ldd ../target/debug/svanill-vault-cli | grep -q libssl
```