### PR TITLE
Consistent filenames

### DIFF
--- a/svanill-vault-server/src/file_server.rs
+++ b/svanill-vault-server/src/file_server.rs
@@ -147,7 +147,7 @@ impl FileServer {
         Ok(())
     }
 
-    pub fn get_presigned_retrieve_url(&self, key: String) -> String {
+    fn get_presigned_retrieve_url(&self, key: String) -> String {
         GetObjectRequest {
             bucket: self.bucket.clone(),
             key,

--- a/svanill-vault-server/src/file_server.rs
+++ b/svanill-vault-server/src/file_server.rs
@@ -118,8 +118,11 @@ impl FileServer {
 
                     let url = self.get_presigned_retrieve_url(key.clone());
 
+                    let (_, filename) = split_object_key(&username, &key)
+                        .expect("object key does not match user prefix");
+
                     Ok::<FileDTO, FileServerError>(FileDTO {
-                        filename: key,
+                        filename: filename.to_owned(),
                         checksum: etag,
                         size: size as i32,
                         url,
@@ -191,6 +194,16 @@ impl FileServer {
 
 fn build_object_key(username: &str, filename: &str) -> String {
     format!("users/{}/{}", username, filename)
+}
+
+fn split_object_key<'a>(username: &str, key: &'a str) -> Option<(&'a str, &'a str)> {
+    let prefix_len = "users/".len() + username.len() + "/".len();
+
+    if prefix_len > key.len() {
+        None
+    } else {
+        Some(key.split_at(prefix_len))
+    }
 }
 
 #[cfg(test)]

--- a/svanill-vault-server/tests/server.rs
+++ b/svanill-vault-server/tests/server.rs
@@ -501,14 +501,14 @@ async fn list_user_files_ok() {
           <MaxKeys>3</MaxKeys>
           <IsTruncated>false</IsTruncated>
           <Contents>
-            <Key>some_object_1.txt</Key>
+            <Key>users/test_user_2/some_object_1.txt</Key>
             <LastModified>2013-09-17T18:07:53.000Z</LastModified>
             <ETag>"599bab3ed2c697f1d26842727561fd94"</ETag>
             <Size>857</Size>
             <StorageClass>REDUCED_REDUNDANCY</StorageClass>
           </Contents>
           <Contents>
-            <Key>some_object_2.txt</Key>
+            <Key>users/test_user_2/any/path/is/ok.txt</Key>
             <LastModified>2013-09-17T18:07:53.000Z</LastModified>
             <ETag>"d26842727561fd94599bab3ed2c697f1"</ETag>
             <Size>346</Size>
@@ -540,6 +540,25 @@ async fn list_user_files_ok() {
 
     assert_eq!(200, json_resp.status);
     assert_eq!(2, json_resp.content.len());
+    assert_eq!("some_object_1.txt", json_resp.content[0].content.filename);
+    assert_eq!(
+        "\"599bab3ed2c697f1d26842727561fd94\"",
+        json_resp.content[0].content.checksum
+    );
+    assert_eq!(857, json_resp.content[0].content.size);
+    assert!(json_resp.content[0].content.url.starts_with(
+        "https://s3.eu-central-1.amazonaws.com/test_bucket/users/test_user_2/some_object_1.txt"
+    ));
+
+    assert_eq!("any/path/is/ok.txt", json_resp.content[1].content.filename);
+    assert_eq!(
+        "\"d26842727561fd94599bab3ed2c697f1\"",
+        json_resp.content[1].content.checksum
+    );
+    assert_eq!(346, json_resp.content[1].content.size);
+    assert!(json_resp.content[1].content.url.starts_with(
+        "https://s3.eu-central-1.amazonaws.com/test_bucket/users/test_user_2/any/path/is/ok.txt"
+    ));
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
Whenever you list files, the `filename` property (not an apt name on insight) should have the `users/<username>/` prefix stripped.
This way you can reuse that same `filename` to update the file (since internally the prefix will be added when requesting the upload endpoint)